### PR TITLE
fix #6 0以上→1以上

### DIFF
--- a/index.html
+++ b/index.html
@@ -2182,7 +2182,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="keyboard-interaction-7">キーボード・インタラクション<a class="self-link" aria-label="§" href="#dialog_modal"></a></h4>
-        <p>以下の記述では、<q>タブ可能要素</q>という用語は、<code>tabindex</code>値が0以上のすべての要素を示します。ただし、0以上の値は、使用しないことが強く勧められていることに、注意してください。</p>
+        <p>以下の記述では、<q>タブ可能要素</q>という用語は、<code>tabindex</code>値が0以上のすべての要素を示します。ただし、1以上の値は、使用しないことが強く勧められていることに、注意してください。</p>
         <ul>
           <li>ダイアログが開くとき、フォーカスはダイアログの中の要素に移動します。初期状態のフォーカスの位置に関しては、以下の注意を見てください。</li>
           <li><kbd>タブ</kbd>:


### PR DESCRIPTION
fix #6
直訳すると「0より大きい」となるのですが、tabindex属性の値には自然数しか指定できないので、日本語としては「1以上」としたほうがより自然で読みやすいように思います。
