### PR TITLE
fix #5 リンクURLを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1276,7 +1276,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </p>
       <section class="notoc">
         <h4 id="example">例<a class="self-link" aria-label="§" href="#accordion"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html">アコーディオンの例:</a>: 3つのセクションに分割された領域を、アコーディオンを使って、1度に1つのセクションを表示するようにしています。</p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html">アコーディオンの例:</a>: 3つのセクションに分割された領域を、アコーディオンを使って、1度に1つのセクションを表示するようにしています。</p>
       </section>
       <section class="notoc">
         <h4 id="keyboard-interaction">キーボード・インタラクション<a class="self-link" aria-label="§" href="#accordion"></a></h4>
@@ -1377,7 +1377,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="example-0">例<a class="self-link" aria-label="§" href="#alert"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/alert/alert.html">アラートの例</a></p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/alert/alert.html">アラートの例</a></p>
       </section>
 
       <section class="notoc">
@@ -1401,7 +1401,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="example-1">例<a class="self-link" aria-label="§" href="#alertdialog"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/alertdialog.html">アラート・ダイアログの例</a>: アラート・ダイアログをデモンストレーションする確認メッセージ</p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/alertdialog.html">アラート・ダイアログの例</a>: アラート・ダイアログをデモンストレーションする確認メッセージ</p>
       </section>
 
       <section class="notoc">
@@ -1442,7 +1442,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="example-2">例<a class="self-link" aria-label="§" href="#breadcrumb"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html">パンくず・デザインパターンの例</a></p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/breadcrumb/index.html">パンくず・デザインパターンの例</a></p>
       </section>
 
       <section class="notoc">
@@ -1494,7 +1494,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="examples">例<a class="self-link" aria-label="§" href="#button"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/button/button.html">ボタンの例</a>: クリック可能なHTMLの<code>div</code>要素と<code>span</code>要素の例です。アクセシブルなコマンドとトグル・ボタンとしています。</p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/button/button.html">ボタンの例</a>: クリック可能なHTMLの<code>div</code>要素と<code>span</code>要素の例です。アクセシブルなコマンドとトグル・ボタンとしています。</p>
       </section>
 
       <section class="notoc">
@@ -1588,7 +1588,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="example-3">例<a class="self-link" aria-label="§" href="#carousel"></a></h4>
         <p>
-          <a href="https://www.w3.org/TR/wai-aria-practices/examples/carousel/carousel-1/carousel-1.html">自動回転するイメージ・カルーセルの例:</a>
+          <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/carousel/carousel-1.html">自動回転するイメージ・カルーセルの例:</a>
           基本的なイメージ・カルーセルで、ページが読み込まれたときに自動的に回転するカルーセルで、アクセシビリティの機能が大切であることをデモンストレーションします。
         </p>
       </section>
@@ -1757,10 +1757,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <h4 id="examples-0">例<a class="self-link" aria-label="§" href="#checkbox"></a></h4>
         <ul>
           <li>
-            <a href="https://www.w3.org/TR/wai-aria-practices/examples/checkbox/checkbox-1/checkbox-1.html">シンプルな2つの状態のチェックボックスの例</a>:シンプル・デュアル・ステート・チェックボックスのデモンストレーションです。　
+            <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/checkbox/checkbox-1/checkbox-1.html">シンプルな2つの状態のチェックボックスの例</a>:シンプル・デュアル・ステート・チェックボックスのデモンストレーションです。　
           </li>
           <li>
-            <a href="https://www.w3.org/TR/wai-aria-practices/examples/checkbox/checkbox-2/checkbox-2.html">トリ・ステート・チェックボックスの例</a>:<code>aria-checked</code>で<code>mixed</code>の値を使い、フィールドセットを備えたチェックボックスのグループ・コレクションを使ったウィジェットの作り方をデモンストレーションします。
+            <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/checkbox/checkbox-2/checkbox-2.html">トリ・ステート・チェックボックスの例</a>:<code>aria-checked</code>で<code>mixed</code>の値を使い、フィールドセットを備えたチェックボックスのグループ・コレクションを使ったウィジェットの作り方をデモンストレーションします。
           </li>
         </ul>
       </section>
@@ -1866,14 +1866,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-1">例<a class="self-link" aria-label="§" href="#combobox"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html">リストボックス・ポップアップを伴ったARIA1.1コンボボックスの例</a>: コンボボックスは、リストボックスポップアップを使ったオートコンプリート動作の様々な形式をデモンストレーションします。ARIA1.1の実装パターンを使用します。
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html">リストボックス・ポップアップを伴ったARIA1.1コンボボックスの例</a>: コンボボックスは、リストボックスポップアップを使ったオートコンプリート動作の様々な形式をデモンストレーションします。ARIA1.1の実装パターンを使用します。
           </li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/grid-combo.html">グリッド・ポップアップを伴ったARIA1.1コンボボックスの例</a>: コンボボックスは、グリッドで、選択肢を表示し、それぞれの選択肢についての説明にユーザをナビゲートすることが可能です。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html">リストと、インライン・オートコンプリートの両方を伴ったARIA1.0コンボボックス</a>: コンボボックスは、<q>インライン・オートコンプリートを伴ったリスト</q>として知られるオートコンプリートの動作をデモンストレーションします。ARIA1.0実装パターンを使用しています。
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/grid-combo.html">グリッド・ポップアップを伴ったARIA1.1コンボボックスの例</a>: コンボボックスは、グリッドで、選択肢を表示し、それぞれの選択肢についての説明にユーザをナビゲートすることが可能です。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html">リストと、インライン・オートコンプリートの両方を伴ったARIA1.0コンボボックス</a>: コンボボックスは、<q>インライン・オートコンプリートを伴ったリスト</q>として知られるオートコンプリートの動作をデモンストレーションします。ARIA1.0実装パターンを使用しています。
           </li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html">リスト・オートコンプリートを伴ったARIA1.0コンボボックス</a>: <q>手動選択のリスト</q>として知られるオートコンプリートの動作をデモンストレーションします。ARIA1.0を使用します。
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html">リスト・オートコンプリートを伴ったARIA1.0コンボボックス</a>: <q>手動選択のリスト</q>として知られるオートコンプリートの動作をデモンストレーションします。ARIA1.0を使用します。
           </li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html">オートコンプリートの無いARIA1.0コンボボックス</a>: コンボ・ボックスは、<code>aria-autocomplete=none</code>となっている動作をデモンストレーションします。ARIA1.0実装パターンを使用します。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html">オートコンプリートの無いARIA1.0コンボボックス</a>: コンボ・ボックスは、<code>aria-autocomplete=none</code>となっている動作をデモンストレーションします。ARIA1.0実装パターンを使用します。</li>
         </ul>
       </section>
 
@@ -2177,7 +2177,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="example-4">例<a class="self-link" aria-label="§" href="#dialog_modal"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html">モーダル・ダイアログの例</a></p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html">モーダル・ダイアログの例</a></p>
       </section>
 
       <section class="notoc">
@@ -2277,8 +2277,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-2">例<a class="self-link" aria-label="§" href="#disclosure"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/disclosure/disclosure-img-long-description.html">画像の解説のディスクロージャ（開/閉）</a></li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/disclosure/disclosure-faq.html">FAQへの回答のディスクロージャ（開/閉）</a></li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/disclosure/disclosure-img-long-description.html">画像の解説のディスクロージャ（開/閉）</a></li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/disclosure/disclosure-faq.html">FAQへの回答のディスクロージャ（開/閉）</a></li>
         </ul>
       </section>
 
@@ -2344,7 +2344,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="example-5">例<a class="self-link" aria-label="§" href="#feed"></a></h4>
         <p>
-          <a href="https://www.w3.org/TR/wai-aria-practices/examples/feed/feed.html">フィード・パターンの実現例</a>
+          <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/feed/feed.html">フィード・パターンの実現例</a>
         </p>
       </section>
 
@@ -2446,9 +2446,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-3">例<a class="self-link" aria-label="§" href="#grid"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/grid/LayoutGrids.html">レイアウト・グリッドの例</a>: それぞれ、ナビゲーション・リンクのコレクション、メッセージの受取人リスト、検索結果のリストを含むレイアウトウィジェットとして使用されている3種類のグリッドの実装例です。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html">データ・グリッドの例</a>: コンテンツ編集やソート、列を非表示にするといった表形式の情報提示に関する機能を含む3種類のグリッドの実装例です。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/grid/advancedDataGrid.html">高度なデータグリッドの例</a>: 行と列のセクションを含む、典型的なスプレッドシートと同等の動作と機能をもつグリッドの例です。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/grid/LayoutGrids.html">レイアウト・グリッドの例</a>: それぞれ、ナビゲーション・リンクのコレクション、メッセージの受取人リスト、検索結果のリストを含むレイアウトウィジェットとして使用されている3種類のグリッドの実装例です。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/grid/dataGrids.html">データ・グリッドの例</a>: コンテンツ編集やソート、列を非表示にするといった表形式の情報提示に関する機能を含む3種類のグリッドの実装例です。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/grid/advancedDataGrid.html">高度なデータグリッドの例</a>: 行と列のセクションを含む、典型的なスプレッドシートと同等の動作と機能をもつグリッドの例です。</li>
         </ul>
       </section>
 
@@ -2779,7 +2779,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="examples-4">例<a class="self-link" aria-label="§" href="#link"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/link/link.html">リンクの例</a>: HTMLの<code>span</code>要素と<code>img</code>要素で構築されたリンク・ウィジェットです。</p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/link/link.html">リンクの例</a>: HTMLの<code>span</code>要素と<code>img</code>要素で構築されたリンク・ウィジェットです。</p>
       </section>
 
       <section class="notoc">
@@ -2817,11 +2817,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-5">例<a class="self-link" aria-label="§" href="#Listbox"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-scrollable.html">スクロール可能なリストボックスの例:</a>: より多くの選択肢を表示するためにスクロールする単一選択リストボックスで、１より大きい<code>size</code>属性をもつHTMLの<code>select</code>要素に似ています。
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/listbox/listbox-scrollable.html">スクロール可能なリストボックスの例:</a>: より多くの選択肢を表示するためにスクロールする単一選択リストボックスで、１より大きい<code>size</code>属性をもつHTMLの<code>select</code>要素に似ています。
           </li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html">折りたたみのドロップダウン・リストボックスの例</a>: アクティブになった時に広がる単一選択の折りたたみリストボックスで、<code>size="1"</code>の属性をもつHTMLの<code>select</code>要素に似ています。
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/listbox/listbox-collapsible.html">折りたたみのドロップダウン・リストボックスの例</a>: アクティブになった時に広がる単一選択の折りたたみリストボックスで、<code>size="1"</code>の属性をもつHTMLの<code>select</code>要素に似ています。
           </li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-rearrangeable.html">再編集可能な選択肢をもつリストボックスの例</a>: ツールバーを付随して、選択肢を追加、移動、削除することが可能な、単一選択と複数選択のリストボックスの例です。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/listbox/listbox-rearrangeable.html">再編集可能な選択肢をもつリストボックスの例</a>: ツールバーを付随して、選択肢を追加、移動、削除することが可能な、単一選択と複数選択のリストボックスの例です。</li>
         </ul>
       </section>
 
@@ -2949,8 +2949,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-6">例<a class="self-link" aria-label="§" href="#menu"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html">ナビゲーション・メニューバーの例</a>:サイト・ナビゲーションを提供するメニューバーを示します。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-2/menubar-2.html">
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html">ナビゲーション・メニューバーの例</a>:サイト・ナビゲーションを提供するメニューバーを示します。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html">
 エディタ・メニューバーの例</a>: テキスト・フィールドを対象としたテキスト形式のコマンドを提供するメニューバーで、そのサブメニューに表示したメニュー・ラジオ（ボタン）とメニュー・チェックボックスをデモンストレーションします。</li>
         </ul>
       </section>
@@ -3121,9 +3121,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-7">例<a class="self-link" aria-label="§" href="#menubutton"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html">ナビゲーション・メニュー・ボタン</a>:HTMLの<code>a</code>要素から作られたメニュー・ボタンです。リンクとして反応する項目のメニューを開きます。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions.html">element.focus()を利用したアクション・メニュー・ボタンの例</a>: HTMLの<code>button</code>要素から作られたメニュー・ボタンです。アクションやコマンドのメニューを開き、メニュー内のフォーカスは、<code>element.focus()</code>を使って管理されています。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions-active-descendant.html">aria-activedescendantを利用したアクション・メニュー・ボタンの例</a>:アクションやコマンドのメニューを開くボタンで、メニュー内のフォーカスがaria-activedescendantを使って管理されています。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-links.html">ナビゲーション・メニュー・ボタン</a>:HTMLの<code>a</code>要素から作られたメニュー・ボタンです。リンクとして反応する項目のメニューを開きます。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-actions.html">element.focus()を利用したアクション・メニュー・ボタンの例</a>: HTMLの<code>button</code>要素から作られたメニュー・ボタンです。アクションやコマンドのメニューを開き、メニュー内のフォーカスは、<code>element.focus()</code>を使って管理されています。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-actions-active-descendant.html">aria-activedescendantを利用したアクション・メニュー・ボタンの例</a>:アクションやコマンドのメニューを開くボタンで、メニュー内のフォーカスがaria-activedescendantを使って管理されています。</li>
         </ul>
       </section>
 
@@ -3168,8 +3168,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-8">例<a class="self-link" aria-label="§" href="#radiobutton"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/radio/radio-1/radio-1.html">ロービング（さまよう）・タブインデックスを使ったラジオ・グループの例</a></li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/radio/radio-2/radio-2.html">aria-activedescendantを使ったラジオ・グループの例</a></li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/radio/radio-1/radio-1.html">ロービング（さまよう）・タブインデックスを使ったラジオ・グループの例</a></li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/radio/radio-2/radio-2.html">aria-activedescendantを使ったラジオ・グループの例</a></li>
         </ul>
       </section>
 
@@ -3239,7 +3239,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <div class="note" role="note" id="issue-container-generatedID-20">
             <div role="heading" class="note-title marker" id="h-note-20" aria-level="6"><span>注意</span></div>
             <p class="">
-              ツールバーのラジオ・ボタンは、よりトグル・ボタンに見える方法で、柔軟にスタイリングされます。例に関しては、「<a href="https://www.w3.org/TR/wai-aria-practices/examples/toolbar/toolbar.html">シンプルなエディターのツールバーの例（Simple Editor Toolbar Example）</a>」を参照してください。
+              ツールバーのラジオ・ボタンは、よりトグル・ボタンに見える方法で、柔軟にスタイリングされます。例に関しては、「<a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/toolbar/toolbar.html">シンプルなエディターのツールバーの例（Simple Editor Toolbar Example）</a>」を参照してください。
             </p>
           </div>
         </section>
@@ -3267,8 +3267,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-9">例<a class="self-link" aria-label="§" href="#slider"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/slider/slider-1.html">水平なスライダーの例</a>: 色設定のコントロールを作るため、3つの水平に並べられたスライダーを使う例をデモンストレーションします。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/slider/slider-2.html">aria-orientationとaria-valuetextのスライダーの例:</a>: 3つのサーモスタット・コントロール・スライダーで、aria-orientationとaria-valuetextの使用をデモンストレーションします。
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/slider/slider-1.html">水平なスライダーの例</a>: 色設定のコントロールを作るため、3つの水平に並べられたスライダーを使う例をデモンストレーションします。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/slider/slider-2.html">aria-orientationとaria-valuetextのスライダーの例:</a>: 3つのサーモスタット・コントロール・スライダーで、aria-orientationとaria-valuetextの使用をデモンストレーションします。
           </li>
         </ul>
       </section>
@@ -3325,7 +3325,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
       <section class="notoc">
         <h4 id="example-6">例<a class="self-link" aria-label="§" href="#slidertwothumb"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/slider/multithumb-slider.html">マルチ親指スライダーの例</a>: 飛行機とホテルの予約のために価格帯を決める2つまみのスライダーを示します。
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/slider/multithumb-slider.html">マルチ親指スライダーの例</a>: 飛行機とホテルの予約のために価格帯を決める2つまみのスライダーを示します。
         </p>
       </section>
 
@@ -3447,7 +3447,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </div>
       <section class="notoc">
         <h4 id="examples-10">例<a class="self-link" aria-label="§" href="#table"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/table/table.html">テーブルの例</a>: ARIAのテーブルがHTMLの<code>div</code>と<code>span</code>の要素で出来ています。</p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/table/table.html">テーブルの例</a>: ARIAのテーブルがHTMLの<code>div</code>と<code>span</code>の要素で出来ています。</p>
       </section>
       <section class="notoc">
         <h4 id="keyboard-interaction-18">キーボード・インタラクション<a class="self-link" aria-label="§" href="#table"></a></h4>
@@ -3509,8 +3509,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-11">例<a class="self-link" aria-label="§" href="#tabpanel"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html">自動アクティベーションのあるタブ・コントロール</a>: タブ・コントロールが自動でアクティブになり、パネルはフォーカスを受け取ると表示されるというタブ・ウィジェットです。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html">手動アクティベーションのあるタブ・コントロール</a>: ユーザーが自分でタブをアクティブにし、そのパネルを表示するには、<kbd>Space</kbd>や<kbd>Enter</kbd>を押すというタブ・ウィジェットです。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html">自動アクティベーションのあるタブ・コントロール</a>: タブ・コントロールが自動でアクティブになり、パネルはフォーカスを受け取ると表示されるというタブ・ウィジェットです。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-2/tabs.html">手動アクティベーションのあるタブ・コントロール</a>: ユーザーが自分でタブをアクティブにし、そのパネルを表示するには、<kbd>Space</kbd>や<kbd>Enter</kbd>を押すというタブ・ウィジェットです。</li>
         </ul>
       </section>
 
@@ -3598,7 +3598,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </ul>
       <section class="notoc">
         <h4 id="example-8">例<a class="self-link" aria-label="§" href="#toolbar"></a></h4>
-        <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/toolbar/toolbar.html">ツールバーの例</a>: フォーカスの管理に「roving tabindex」を使用し、トグル・ボタン、ラジオ・ボタン、メニュー・ボタン、スピン・ボタン、チェックボックス、リンクを含む、いくつかのタイプのコントロールを含みます。(「roving tabindex」は、5.6.1に記載がある。5.6.1に記載のフォーカス管理方法を、「roving tabindex」と名付けているように見える。現段階で訳しにくいので、このままで、表記。)</p>
+        <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/toolbar/toolbar.html">ツールバーの例</a>: フォーカスの管理に「roving tabindex」を使用し、トグル・ボタン、ラジオ・ボタン、メニュー・ボタン、スピン・ボタン、チェックボックス、リンクを含む、いくつかのタイプのコントロールを含みます。(「roving tabindex」は、5.6.1に記載がある。5.6.1に記載のフォーカス管理方法を、「roving tabindex」と名付けているように見える。現段階で訳しにくいので、このままで、表記。)</p>
       </section>
       <section class="notoc">
         <h4 id="keyboard-interaction-20">キーボード・インタラクション<a class="self-link" aria-label="§" href="#toolbar"></a></h4>
@@ -3703,12 +3703,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <section class="notoc">
         <h4 id="examples-12">例<a class="self-link" aria-label="§" href="#TreeView"></a></h4>
         <ul>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-1/treeview-1a.html">計算されたプロパティを使うファイル・ディレクトリ・ツリービューの例</a>:ファイルを選択するツリーです。DOMの構造で自動的に計算する<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、ブラウザのサポートをデモンストレーションします。</li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-1/treeview-1b.html">宣言されたプロパティを使うファイル・ディレクトリ・ツリービューの例</a>:ファイルを選択するツリーです。<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、値を明確に定義する方法をデモンストレーションします。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-1/treeview-1a.html">計算されたプロパティを使うファイル・ディレクトリ・ツリービューの例</a>:ファイルを選択するツリーです。DOMの構造で自動的に計算する<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、ブラウザのサポートをデモンストレーションします。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-1/treeview-1b.html">宣言されたプロパティを使うファイル・ディレクトリ・ツリービューの例</a>:ファイルを選択するツリーです。<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、値を明確に定義する方法をデモンストレーションします。</li>
           <li>
-            <a href="https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-2/treeview-2a.html">計算されたプロパティを使うナビゲーション・ツリービューの例</a>:1セットのウェブ・ページへのナビゲーションを提供するツリーです。DOMの構造で自動的に計算する<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、ブラウザのサポートをデモンストレーションします。
+            <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html">計算されたプロパティを使うナビゲーション・ツリービューの例</a>:1セットのウェブ・ページへのナビゲーションを提供するツリーです。DOMの構造で自動的に計算する<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、ブラウザのサポートをデモンストレーションします。
           </li>
-          <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-2/treeview-2b.html">宣言されたプロパティを使うナビゲーション・ツリービューの例</a>:1セットのウェブ・ページへのナビゲーションを提供するツリーです。<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、値を明確に定義する方法をデモンストレーションします。</li>
+          <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2b.html">宣言されたプロパティを使うナビゲーション・ツリービューの例</a>:1セットのウェブ・ページへのナビゲーションを提供するツリーです。<code>aria-level</code>、<code>aria-posinset</code>、<code>aria-setsize</code>について、値を明確に定義する方法をデモンストレーションします。</li>
         </ul>
       </section>
 
@@ -3849,7 +3849,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <h4 id="examples-13">例<a class="self-link" aria-label="§" href="#treegrid"></a></h4>
         <ul>
           <li>
-            <a href="https://www.w3.org/TR/wai-aria-practices/examples/treegrid/treegrid-1.html">E-Mail受信トレイ<code>treegrid</code>の例</a>: e-mailの受診トレイを操作するツリーグリッドです。「行優先」、「セル優先」、「セルのみ」の、3つのキーボード・ナビゲーション・モデルをデモンストレーションします。
+            <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/treegrid/treegrid-1.html">E-Mail受信トレイ<code>treegrid</code>の例</a>: e-mailの受診トレイを操作するツリーグリッドです。「行優先」、「セル優先」、「セルのみ」の、3つのキーボード・ナビゲーション・モデルをデモンストレーションします。
           </li>
         </ul>
       </section>
@@ -4213,7 +4213,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section class="notoc">
           <h5 id="examples-14">例<a class="self-link" aria-label="§" href="#aria_lh_banner"></a></h5>
 
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/banner.html">Bannerランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/banner.html">Bannerランドマークの例</a></p>
         </section>
 
       </section>
@@ -4239,7 +4239,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section class="notoc">
           <h5 id="examples-15">例<a class="self-link" aria-label="§" href="#aria_lh_complementary"></a></h5>
 
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/complementary.html">Complementaryランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/complementary.html">Complementaryランドマークの例</a></p>
         </section>
       </section>
 
@@ -4283,7 +4283,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
         <section class="notoc">
           <h5 id="examples-16">例<a class="self-link" aria-label="§" href="#aria_lh_contentinfo"></a></h5>
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/contentinfo.html">Contentinfoランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/contentinfo.html">Contentinfoランドマークの例</a></p>
         </section>
       </section>
 
@@ -4322,7 +4322,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section class="notoc">
           <h5 id="examples-17">例<a class="self-link" aria-label="§" href="#aria_lh_form"></a></h5>
 
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/form.html">formランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/form.html">formランドマークの例</a></p>
         </section>
       </section>
 
@@ -4354,7 +4354,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section class="notoc">
           <h5 id="examples-18">例<a class="self-link" aria-label="§" href="#aria_lh_main"></a></h5>
 
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/main.html">mainランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/main.html">mainランドマークの例</a></p>
         </section>
       </section>
 
@@ -4383,7 +4383,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section class="notoc">
           <h5 id="examples-19">例<a class="self-link" aria-label="§" href="#aria_lh_navigation"></a></h5>
 
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/navigation.html">navigationランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/navigation.html">navigationランドマークの例</a></p>
         </section>
       </section>
 
@@ -4413,7 +4413,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section class="notoc">
           <h5 id="examples-20">例<a class="self-link" aria-label="§" href="#aria_lh_region"></a></h5>
 
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/region.html">regionランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/region.html">regionランドマークの例</a></p>
         </section>
       </section>
 
@@ -4440,7 +4440,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section class="notoc">
           <h5 id="examples-21">例<a class="self-link" aria-label="§" href="#aria_lh_search"></a></h5>
 
-          <p><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/search.html">searchランドマークの例</a></p>
+          <p><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/search.html">searchランドマークの例</a></p>
         </section>
       </section>
     </section>
@@ -5475,8 +5475,8 @@ role=<code>presentation</code>によるセマンティックの意図的な隠�
     <!--OddPage-->
     <h2 id="a-indexes"><span class="secno">A. </span>索引<a class="self-link" aria-label="§" href="#indexes"></a></h2>
     <ul>
-      <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/#examples_by_role_label">Roleに関するデザイン・パターンの例</a></li>
-      <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/#examples_by_props_label">プロパティと状態によるデザイン・パターンの例</a> </li>
+      <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/#examples_by_role_label">Roleに関するデザイン・パターンの例</a></li>
+      <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/#examples_by_props_label">プロパティと状態によるデザイン・パターンの例</a> </li>
     </ul>
   </section>
 


### PR DESCRIPTION
fix #5 
指摘箇所のリンクのURLを修正。
全体的にサンプルへのリンク URL が /wai-aria-practices/ に向いていましたが、これは最新版である 1.2 のサンプルを指しており、1.2 で削除されたサンプルが消えているという問題があるため、URLを /wai-aria-practices-1.1/ に向けるようにしました。